### PR TITLE
Add impressum, cookie consent, and DSGVO compliance

### DIFF
--- a/.github/workflows/jekyll_build.yml
+++ b/.github/workflows/jekyll_build.yml
@@ -3,8 +3,6 @@ name: Build and Test Jekyll Site
 on:
   pull_request:
     branches: ["main"]
-  push:
-    branches-ignore: ["main"]
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ external_resources/
 
 # PostHog configuration with secrets
 _config_posthog_local.yml
+
+# Caude Plans
+.claude/plans/

--- a/_includes/cookie-consent.html
+++ b/_includes/cookie-consent.html
@@ -1,0 +1,119 @@
+{% comment %} Cookie Consent Banner — orestbida/cookieconsent v3
+Blocks PostHog analytics until user opts in. Bilingual DE/EN. {% endcomment %}
+
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@v3.1.0/dist/cookieconsent.css">
+<script defer src="https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@v3.1.0/dist/cookieconsent.umd.js"></script>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var lang = '{{ page.lang | default: site.default_language | default: "de" }}';
+
+    CookieConsent.run({
+        guiOptions: {
+            consentModal: {
+                layout: 'box inline',
+                position: 'bottom right'
+            },
+            preferencesModal: {
+                layout: 'box'
+            }
+        },
+
+        categories: {
+            necessary: {
+                enabled: true,
+                readOnly: true
+            },
+            analytics: {}
+        },
+
+        onConsent: function () {
+            if (CookieConsent.acceptedCategory('analytics')) {
+                if (window.posthog) {
+                    window.posthog.opt_in_capturing();
+                }
+            }
+        },
+
+        onChange: function (param) {
+            if (!window.posthog) return;
+
+            if (param.changedCategories.indexOf('analytics') !== -1) {
+                if (CookieConsent.acceptedCategory('analytics')) {
+                    window.posthog.opt_in_capturing();
+                } else {
+                    window.posthog.opt_out_capturing();
+                }
+            }
+        },
+
+        language: {
+            default: lang,
+            translations: {
+                de: {
+                    consentModal: {
+                        title: 'Cookie-Einstellungen',
+                        description: 'Diese Website verwendet Cookies und Analysetools, um Ihnen das bestmögliche Erlebnis zu bieten. Sie können selbst entscheiden, welche Kategorien Sie zulassen möchten.',
+                        acceptAllBtn: 'Alle akzeptieren',
+                        acceptNecessaryBtn: 'Nur notwendige',
+                        showPreferencesBtn: 'Einstellungen'
+                    },
+                    preferencesModal: {
+                        title: 'Cookie-Einstellungen',
+                        acceptAllBtn: 'Alle akzeptieren',
+                        acceptNecessaryBtn: 'Nur notwendige',
+                        savePreferencesBtn: 'Auswahl speichern',
+                        sections: [
+                            {
+                                title: 'Cookie-Nutzung',
+                                description: 'Wir verwenden Cookies, um die grundlegenden Funktionen der Website sicherzustellen und Ihr Online-Erlebnis zu verbessern. Für jede Kategorie können Sie entscheiden, ob Sie zustimmen möchten.'
+                            },
+                            {
+                                title: 'Notwendige Cookies',
+                                description: 'Diese Cookies sind für das Funktionieren der Website erforderlich und können nicht deaktiviert werden.',
+                                linkedCategory: 'necessary'
+                            },
+                            {
+                                title: 'Analyse-Cookies',
+                                description: 'Wir verwenden PostHog (EU-Server, Frankfurt) zur anonymen Auswertung der Website-Nutzung. Es werden keine personenbezogenen Daten erfasst. <a href="/privacy/">Mehr erfahren</a>',
+                                linkedCategory: 'analytics'
+                            }
+                        ]
+                    }
+                },
+                en: {
+                    consentModal: {
+                        title: 'Cookie Settings',
+                        description: 'This website uses cookies and analytics tools to provide you with the best possible experience. You can choose which categories to allow.',
+                        acceptAllBtn: 'Accept all',
+                        acceptNecessaryBtn: 'Necessary only',
+                        showPreferencesBtn: 'Settings'
+                    },
+                    preferencesModal: {
+                        title: 'Cookie Settings',
+                        acceptAllBtn: 'Accept all',
+                        acceptNecessaryBtn: 'Necessary only',
+                        savePreferencesBtn: 'Save preferences',
+                        sections: [
+                            {
+                                title: 'Cookie Usage',
+                                description: 'We use cookies to ensure the basic functions of the website and to enhance your online experience. You can choose whether to opt in to each category.'
+                            },
+                            {
+                                title: 'Necessary Cookies',
+                                description: 'These cookies are essential for the website to function and cannot be disabled.',
+                                linkedCategory: 'necessary'
+                            },
+                            {
+                                title: 'Analytics Cookies',
+                                description: 'We use PostHog (EU servers, Frankfurt) for anonymous analysis of website usage. No personal data is collected. <a href="/en/privacy/">Learn more</a>',
+                                linkedCategory: 'analytics'
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    });
+});
+</script>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,13 +7,13 @@
     <span class="separator">|</span>
     <a href="{{ '/en/privacy/' | relative_url }}">Privacy Policy</a>
     <span class="separator">|</span>
-    <a href="#" data-cc="show-preferencesModal">Cookie Settings</a>
+    <button type="button" data-cc="show-preferencesModal">Cookie Settings</button>
     {% else %}
     <a href="{{ '/impressum/' | relative_url }}">Impressum</a>
     <span class="separator">|</span>
     <a href="{{ '/privacy/' | relative_url }}">Datenschutz</a>
     <span class="separator">|</span>
-    <a href="#" data-cc="show-preferencesModal">Cookie-Einstellungen</a>
+    <button type="button" data-cc="show-preferencesModal">Cookie-Einstellungen</button>
     {% endif %}
   </div>
   {% include language-switcher.html %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,38 +1,20 @@
-<footer class="site-footer h-card">
-  <data class="u-url" href="{{ "/" | relative_url }}"></data>
-
-  <div class="wrapper">
-
-    <h2 class="footer-heading">{{ site.title | escape }}</h2>
-
-    <div class="footer-col-wrapper">
-      <div class="footer-col footer-col-1">
-        <ul class="contact-list">
-          <li class="p-name">
-            {%- if site.author.name -%}
-              {{ site.author.name | escape }}
-            {%- else -%}
-              {{ site.title | escape }}
-            {%- endif -%}
-            </li>
-            {%- if site.email -%}
-            <li><a class="u-email" href="mailto:{{ site.email }}">{{ site.email }}</a></li>
-            {%- endif -%}
-            {%- if site.author.phone -%}
-            <li>{{ site.author.phone }}</li>
-            {%- endif -%}
-        </ul>
-      </div>
-
-      <div class="footer-col footer-col-2">
-        {%- include social.html -%}
-      </div>
-
-      <div class="footer-col footer-col-3">
-        <p>{{- site.description | escape -}}</p>
-      </div>
-    </div>
-
+<footer>
+  <p>© 2024 {{ site.author.name }} - {{ site.author.title }}</p>
+  <p>Kontakt: <a href="mailto:{{ site.email }}">{{ site.email }}</a> | <a href="tel:{{ site.author.phone }}">{{ site.author.phone }}</a></p>
+  <div class="footer-legal">
+    {% if page.lang == "en" %}
+    <a href="{{ '/en/impressum/' | relative_url }}">Imprint</a>
+    <span class="separator">|</span>
+    <a href="{{ '/en/privacy/' | relative_url }}">Privacy Policy</a>
+    <span class="separator">|</span>
+    <a href="#" data-cc="show-preferencesModal">Cookie Settings</a>
+    {% else %}
+    <a href="{{ '/impressum/' | relative_url }}">Impressum</a>
+    <span class="separator">|</span>
+    <a href="{{ '/privacy/' | relative_url }}">Datenschutz</a>
+    <span class="separator">|</span>
+    <a href="#" data-cc="show-preferencesModal">Cookie-Einstellungen</a>
+    {% endif %}
   </div>
-
+  {% include language-switcher.html %}
 </footer>

--- a/_includes/posthog.html
+++ b/_includes/posthog.html
@@ -71,6 +71,7 @@ _config_posthog_local.yml. {% endcomment %}
         posthog.init(posthogApiKey, {
             api_host: posthogHost,
             respect_dnt: true,
+            opt_out_capturing_by_default: true,
             capture_pageview: true,
             capture_pageleave: true,
         });

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,12 +46,9 @@
       {{ content }}
 
       </section>
-      <footer>
-        <p>© 2024 {{ site.author.name }} - {{ site.author.title }}</p>
-        <p>Kontakt: <a href="mailto:{{ site.email }}">{{ site.email }}</a> | <a href="tel:{{ site.author.phone }}">{{ site.author.phone }}</a></p>
-        {% include language-switcher.html %}
-      </footer>
+      {% include footer.html %}
     </div>
     <script src="{{ "/assets/js/scale.fix.js" | relative_url }}"></script>
+    {% include cookie-consent.html %}
   </body>
 </html>

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -492,3 +492,36 @@ footer {
     margin-left: 1.5rem;
   }
 }
+
+// Cookie Consent Banner — brand color overrides
+#cc-main {
+  --cc-btn-primary-bg: var(--brand-orange);
+  --cc-btn-primary-hover-bg: #d35400;
+  --cc-btn-primary-color: #fff;
+  --cc-btn-secondary-bg: var(--brand-sage);
+  --cc-btn-secondary-hover-bg: var(--brand-sage-dark);
+  --cc-btn-secondary-color: #fff;
+  --cc-toggle-on-bg: var(--brand-sage);
+  --cc-link-color: var(--brand-sage);
+  --cc-separator-border-color: var(--border-light);
+  --cc-bg: #fff;
+  --cc-font-family: inherit;
+}
+
+.footer-legal {
+  margin-top: 0.5rem;
+  font-size: 0.85em;
+
+  a {
+    color: var(--brand-sage) !important;
+
+    &:hover {
+      color: var(--brand-sage-dark) !important;
+    }
+  }
+
+  .separator {
+    margin: 0 0.3em;
+    color: var(--text-light);
+  }
+}

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -512,12 +512,21 @@ footer {
   margin-top: 0.5rem;
   font-size: 0.85em;
 
-  a {
+  a, button {
     color: var(--brand-sage) !important;
 
     &:hover {
       color: var(--brand-sage-dark) !important;
     }
+  }
+
+  button {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+    text-decoration: underline;
   }
 
   .separator {

--- a/en/impressum.md
+++ b/en/impressum.md
@@ -1,0 +1,64 @@
+---
+layout: default
+title: Imprint
+lang: en
+permalink: /en/impressum/
+---
+
+# Imprint (Impressum)
+
+## Information pursuant to § 5 DDG (German Digital Services Act)
+
+**Anne-Ruth Moltmann-Willisch, LL.M.**
+Former Regional Court Judge, Mediator
+
+Fritschestr. 22
+10585 Berlin, Germany
+
+## Contact
+
+**Phone:** [+49 (0) 172 65 29 460](tel:+4917265229460)
+**Email:** [ar.moltmannwillisch@gmail.com](mailto:ar.moltmannwillisch@gmail.com)
+
+## Professional Title
+
+**Title:** Mediator (Mediatorin)
+**Awarded in:** Federal Republic of Germany
+
+Supervisory authority: none (liberal profession)
+
+Applicable professional regulations:
+- [German Mediation Act (MediationsG)](https://www.gesetze-im-internet.de/mediationsg/)
+- [ZMediatAusbV](https://www.gesetze-im-internet.de/zmediatausbv/)
+
+## Editorially Responsible
+
+Anne-Ruth Moltmann-Willisch, LL.M.
+Fritschestr. 22, 10585 Berlin
+
+## Dispute Resolution
+
+The European Commission provides an online dispute resolution (ODR) platform:
+[https://ec.europa.eu/consumers/odr/](https://ec.europa.eu/consumers/odr/)
+
+I am neither willing nor obliged to participate in dispute resolution proceedings before a consumer arbitration board.
+
+## Liability for Content
+
+As a service provider, I am responsible under § 7 para. 1 DDG for my own content on these pages in accordance with general laws. However, under §§ 8 to 10 DDG, I am not obligated to monitor transmitted or stored third-party information or to investigate circumstances indicating illegal activity.
+
+Obligations to remove or block the use of information under general laws remain unaffected. However, liability in this regard is only possible from the point in time at which a concrete legal infringement becomes known. Upon becoming aware of corresponding legal violations, I will remove this content immediately.
+
+## Liability for Links
+
+This website contains links to external third-party websites over whose content I have no influence. Therefore, I cannot assume any liability for this third-party content. The respective provider or operator of the linked pages is always responsible for their content. The linked pages were checked for possible legal violations at the time of linking. Illegal content was not recognizable at the time of linking.
+
+Permanent monitoring of the content of the linked pages is not reasonable without concrete evidence of a legal violation. Upon becoming aware of legal violations, I will remove such links immediately.
+
+## Copyright
+
+The content and works on these pages created by the site operator are subject to German copyright law. Duplication, processing, distribution, and any kind of exploitation outside the limits of copyright require the written consent of the respective author or creator. Downloads and copies of this site are only permitted for private, non-commercial use.
+
+## Design and Implementation
+
+Website concept and implementation: Jakob Willisch, Berlin

--- a/impressum.md
+++ b/impressum.md
@@ -1,0 +1,64 @@
+---
+layout: default
+title: Impressum
+lang: de
+permalink: /impressum/
+---
+
+# Impressum
+
+## Angaben gemäß § 5 DDG
+
+**Anne-Ruth Moltmann-Willisch, LL.M.**
+Richterin am Landgericht a.D., Mediatorin
+
+Fritschestr. 22
+10585 Berlin
+
+## Kontakt
+
+**Telefon:** [+49 (0) 172 65 29 460](tel:+4917265229460)
+**E-Mail:** [ar.moltmannwillisch@gmail.com](mailto:ar.moltmannwillisch@gmail.com)
+
+## Berufsbezeichnung
+
+**Berufsbezeichnung:** Mediatorin
+**Verliehen in:** Bundesrepublik Deutschland
+
+Zuständige Aufsichtsbehörde: keine (freier Beruf)
+
+Berufsrechtliche Regelungen:
+- [Mediationsgesetz (MediationsG)](https://www.gesetze-im-internet.de/mediationsg/)
+- [ZMediatAusbV](https://www.gesetze-im-internet.de/zmediatausbv/)
+
+## Redaktionell verantwortlich
+
+Anne-Ruth Moltmann-Willisch, LL.M.
+Fritschestr. 22, 10585 Berlin
+
+## Streitschlichtung
+
+Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit:
+[https://ec.europa.eu/consumers/odr/](https://ec.europa.eu/consumers/odr/)
+
+Ich bin nicht bereit oder verpflichtet, an Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle teilzunehmen.
+
+## Haftung für Inhalte
+
+Als Diensteanbieterin bin ich gemäß § 7 Abs. 1 DDG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 DDG bin ich als Diensteanbieterin jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen.
+
+Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung möglich. Bei Bekanntwerden entsprechender Rechtsverletzungen werde ich diese Inhalte umgehend entfernen.
+
+## Haftung für Links
+
+Mein Angebot enthält Links zu externen Websites Dritter, auf deren Inhalte ich keinen Einfluss habe. Deshalb kann ich für diese fremden Inhalte auch keine Gewähr übernehmen. Für die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten wurden zum Zeitpunkt der Verlinkung auf mögliche Rechtsverstöße überprüft. Rechtswidrige Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennbar.
+
+Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist jedoch ohne konkrete Anhaltspunkte einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von Rechtsverletzungen werde ich derartige Links umgehend entfernen.
+
+## Urheberrecht
+
+Die durch die Seitenbetreiberin erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen Urheberrecht. Die Vervielfältigung, Bearbeitung, Verbreitung und jede Art der Verwertung außerhalb der Grenzen des Urheberrechtes bedürfen der schriftlichen Zustimmung der jeweiligen Autorin bzw. Erstellerin. Downloads und Kopien dieser Seite sind nur für den privaten, nicht kommerziellen Gebrauch gestattet.
+
+## Gestaltung und Umsetzung
+
+Website-Konzeption und Umsetzung: Jakob Willisch, Berlin

--- a/privacy.md
+++ b/privacy.md
@@ -62,7 +62,34 @@ Soweit innerhalb dieser Datenschutzerklärung keine speziellere Speicherdauer ge
 ### Hinweis zur Datenweitergabe in die USA
 Auf unserer Website sind unter anderem Tools von Unternehmen mit Sitz in den USA eingebunden. Wenn diese Tools aktiv sind, können Ihre personenbezogenen Daten an die US-Server der jeweiligen Unternehmen übertragen werden.
 
-## 4. Datenerfassung auf dieser Website
+## 4. Analyse-Tools
+
+### PostHog
+
+Diese Website nutzt PostHog, einen Webanalysedienst. Anbieter ist die PostHog Inc., mit EU-Datenverarbeitung unter `eu.i.posthog.com`.
+
+**Erfasste Daten:**
+- Seitenaufrufe und Seitenverweildauer
+- Klicks auf Telefon- und E-Mail-Links
+- Interaktionen mit dem Kontaktformular (Start, Themenauswahl, Absendung)
+- Klicks auf Beratungs-Links
+- Technische Daten (Browser, Betriebssystem, Bildschirmauflösung)
+
+**Keine Erfassung von:** Namen, E-Mail-Adressen, Nachrichteninhalten oder sonstigen personenbezogenen Kontaktdaten über PostHog.
+
+**Rechtsgrundlage:** Art. 6 Abs. 1 lit. a DSGVO (Einwilligung). Die Analyse erfolgt nur nach Ihrer Einwilligung über unseren Cookie-Hinweis.
+
+**Speicherdauer:** Die Daten werden nach 12 Monaten automatisch gelöscht.
+
+**Serverstandort:** Europäische Union (Frankfurt). Es findet keine Datenübertragung in die USA statt.
+
+**Do Not Track:** PostHog respektiert die „Do Not Track"-Einstellung Ihres Browsers. Ist diese aktiviert, erfolgt keine Datenerfassung.
+
+**Opt-Out:** Sie können die Erfassung jederzeit über Ihre Cookie-Einstellungen widerrufen oder die „Do Not Track"-Funktion Ihres Browsers aktivieren.
+
+**Weitere Informationen:** [PostHog Datenschutzerklärung](https://posthog.com/privacy)
+
+## 5. Datenerfassung auf dieser Website
 
 ### Server-Log-Dateien
 Der Provider der Seiten erhebt und speichert automatisch Informationen in so genannten Server-Log-Dateien, die Ihr Browser automatisch an uns übermittelt. Dies sind:
@@ -76,14 +103,22 @@ Der Provider der Seiten erhebt und speichert automatisch Informationen in so gen
 
 Eine Zusammenführung dieser Daten mit anderen Datenquellen wird nicht vorgenommen. Die Erfassung dieser Daten erfolgt auf Grundlage von Art. 6 Abs. 1 lit. f DSGVO.
 
-### Kontaktformular
-Wenn Sie uns per Kontaktformular Anfragen zukommen lassen, werden Ihre Angaben aus dem Anfrageformular inklusive der von Ihnen dort angegebenen Kontaktdaten zwecks Bearbeitung der Anfrage und für den Fall von Anschlussfragen bei uns gespeichert.
+### Kontaktformular (Web3Forms)
+Wenn Sie uns per Kontaktformular Anfragen zukommen lassen, werden Ihre Angaben über den Dienst Web3Forms übermittelt. Anbieter ist Web3Forms (web3forms.com).
 
-Die Verarbeitung dieser Daten erfolgt auf Grundlage von Art. 6 Abs. 1 lit. b DSGVO, sofern Ihre Anfrage mit der Erfüllung eines Vertrags zusammenhängt oder zur Durchführung vorvertraglicher Maßnahmen erforderlich ist. In allen übrigen Fällen beruht die Verarbeitung auf unserem berechtigten Interesse an der effektiven Bearbeitung der an uns gerichteten Anfragen (Art. 6 Abs. 1 lit. f DSGVO) oder auf Ihrer Einwilligung (Art. 6 Abs. 1 lit. a DSGVO) sofern diese abgefragt wurde.
+**Übermittelte Daten:**
+- Name, E-Mail-Adresse, Telefonnummer (falls angegeben)
+- Betreff und Nachrichteninhalt
 
-Die von Ihnen im Kontaktformular eingegebenen Daten verbleiben bei uns, bis Sie uns zur Löschung auffordern, Ihre Einwilligung zur Speicherung widerrufen oder der Zweck für die Datenspeicherung entfällt. Zwingende gesetzliche Bestimmungen – insbesondere Aufbewahrungsfristen – bleiben unberührt.
+**Verarbeitung durch Web3Forms:** Web3Forms leitet Ihre Nachricht per E-Mail an uns weiter. Die Daten werden von Web3Forms nicht dauerhaft gespeichert und nicht für eigene Zwecke verwendet. Weitere Informationen: [Web3Forms Privacy Policy](https://web3forms.com/privacy)
 
-## 5. Ihre Rechte
+**Rechtsgrundlage:** Art. 6 Abs. 1 lit. b DSGVO, sofern Ihre Anfrage mit der Erfüllung eines Vertrags zusammenhängt oder zur Durchführung vorvertraglicher Maßnahmen erforderlich ist. In allen übrigen Fällen beruht die Verarbeitung auf unserem berechtigten Interesse an der effektiven Bearbeitung der an uns gerichteten Anfragen (Art. 6 Abs. 1 lit. f DSGVO) oder auf Ihrer Einwilligung (Art. 6 Abs. 1 lit. a DSGVO) sofern diese abgefragt wurde.
+
+**Speicherdauer:** Die von Ihnen im Kontaktformular eingegebenen Daten verbleiben bei uns, bis Sie uns zur Löschung auffordern, Ihre Einwilligung zur Speicherung widerrufen oder der Zweck für die Datenspeicherung entfällt. Zwingende gesetzliche Bestimmungen – insbesondere Aufbewahrungsfristen – bleiben unberührt.
+
+**Serverstandort:** Web3Forms verarbeitet Daten auf Servern, die ggf. außerhalb der EU liegen. Die Übermittlung erfolgt auf Grundlage von Art. 49 Abs. 1 lit. b DSGVO (Vertragserfüllung).
+
+## 6. Ihre Rechte
 
 ### Auskunft, Löschung und Berichtigung
 Sie haben im Rahmen der geltenden gesetzlichen Bestimmungen jederzeit das Recht auf unentgeltliche Auskunft über Ihre gespeicherten personenbezogenen Daten, deren Herkunft und Empfänger und den Zweck der Datenverarbeitung und ggf. ein Recht auf Berichtigung oder Löschung dieser Daten.
@@ -97,7 +132,7 @@ Sie haben das Recht, Daten, die wir auf Grundlage Ihrer Einwilligung oder in Erf
 ### Widerspruch gegen Werbe-E-Mails
 Der Nutzung von im Rahmen der Impressumspflicht veröffentlichten Kontaktdaten zur Übersendung von nicht ausdrücklich angeforderter Werbung und Informationsmaterialien wird hiermit widersprochen.
 
-## 6. Besondere Hinweise für Mediationsverfahren
+## 7. Besondere Hinweise für Mediationsverfahren
 
 ### Verschwiegenheitspflicht
 Als Mediatorin unterliege ich der gesetzlichen Verschwiegenheitspflicht nach § 4 Mediationsgesetz (MediationsG). Alle im Rahmen einer Mediation bekannt gewordenen Informationen werden streng vertraulich behandelt.
@@ -107,6 +142,6 @@ Bei Mediationsverfahren werden nur die für das Verfahren notwendigen Daten erho
 
 ---
 
-**Stand dieser Datenschutzerklärung**: November 2024
+**Stand dieser Datenschutzerklärung**: Mai 2026
 
 Bei Fragen zum Datenschutz kontaktieren Sie mich gerne unter ar.moltmannwillisch@gmail.com


### PR DESCRIPTION
## Summary

- **Impressum (DE/EN):** Complete legal notice pages based on familienkokon template — address, contact, professional title, liability disclaimers, copyright, credits
- **Cookie consent banner:** DSGVO-compliant opt-in consent using orestbida/cookieconsent v3 (CDN-loaded, ~5KB). PostHog blocked by default, only activated after explicit consent
- **Privacy policy updates:** Added PostHog analytics section (EU servers, data collected, legal basis, opt-out) and Web3Forms contact form processor disclosure
- **Footer refactor:** Extracted into reusable `_includes/footer.html` with language-aware Impressum/Datenschutz/Cookie-Einstellungen links

## Test plan

- [x] `bundle exec jekyll serve` builds without errors
- [x] Cookie banner appears on first visit (bottom right, brand colors)
- [x] Accepting analytics → PostHog starts capturing (check network tab for eu.i.posthog.com)
- [x] Rejecting → no PostHog cookies or requests
- [x] Footer "Cookie-Einstellungen" link reopens preferences modal
- [x] Banner respects language (DE on `/`, EN on `/en/` pages)
- [x] Impressum pages render correctly at `/impressum/` and `/en/impressum/`
- [x] Privacy policy sections numbered correctly, PostHog + Web3Forms sections present
- [x] Consent persists across page navigation (localStorage)

Assisted-by: claude-opus-4-6